### PR TITLE
Added second export for non-split UMCs

### DIFF
--- a/R/05_prepare-clinical-dashboard-data.R
+++ b/R/05_prepare-clinical-dashboard-data.R
@@ -9,7 +9,7 @@ library(here)
 
 intovalue <- read_rds(here("data", "processed", "intovalue.rds"))
 
-ct_intovalue <-
+ct_intovalue_umc <-
 
   intovalue %>%
 
@@ -30,4 +30,22 @@ ct_intovalue <-
   mutate(lead_cities = strsplit(as.character(lead_cities), " ")) %>%
   tidyr::unnest(lead_cities)
 
-write_csv(ct_intovalue, here("data", "processed", "ct-dashboard-intovalue.csv"))
+write_csv(ct_intovalue_umc, here("data", "processed", "ct-dashboard-intovalue-umc.csv"))
+
+ct_intovalue_all <-
+
+  intovalue %>%
+
+  filter(
+
+    # Re-apply the IntoValue exclusion criteria
+    iv_completion,
+    iv_status,
+    iv_interventional,
+    has_german_umc_lead,
+
+    # In case of dupes, exclude IV1 version
+    !(is_dupe & iv_version == 1)
+  )
+
+write_csv(ct_intovalue_all, here("data", "processed", "ct-dashboard-intovalue-all.csv"))


### PR DESCRIPTION
I just edited so that it writes out both a split and a non-split version of the CSV for use in the dashboard