### PR TITLE
Re-classify API response with 0 months embargo

### DIFF
--- a/scripts/13_get-oa-permissions.py
+++ b/scripts/13_get-oa-permissions.py
@@ -154,6 +154,7 @@ def main():
 
     unresolved_dois = []
     no_best_perm_dois = []
+    no_embargo_info_dois = []
     syp_response = []
     result = []
 
@@ -175,7 +176,12 @@ def main():
             syp_response.append((doi, "no_best_permission"))
             continue
 
-        syp_response.append((doi, "response"))
+        if output["best_permission"].get("embargo_months") is None:
+            print(f"NO EMBARGO: {doi}")
+            no_embargo_info_dois.append(doi)
+            syp_response.append((doi, "no_embargo_info"))
+        else:
+            syp_response.append((doi, "response"))
         result.append((doi, ) + tmp)
 
     # Create a dataframe to store the results
@@ -197,6 +203,7 @@ def main():
 
     print("Number of unresolved DOIs: ", len(unresolved_dois))
     print("Number of DOIs without a best permission: ", len(no_best_perm_dois))
+    print("Number of DOIs without embargo information: ", len(no_embargo_info_dois))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Re-classified cases where there is an API response with a best permission but 0 months embargo to `syp_response` = "response"
- Want to reserve "no_embargo" category for cases where there is an API response with a best permission, but no embargo information was found
- Renamed "no_embargo" to "no_embargo_info" for clarity