### PR TITLE
Fix bug in drks summary results and add assertion

### DIFF
--- a/scripts/15_validate-trials.R
+++ b/scripts/15_validate-trials.R
@@ -62,4 +62,24 @@ trials %>%
   pointblank::col_vals_not_null(
     vars(publication_date),
     preconditions = ~ . %>% filter(publication_type == "journal article")
+  ) %>%
+
+  # Check that trial has summary results if summary results date, and vice versa
+  pointblank::col_vals_equal(
+    vars(has_summary_results),
+    TRUE,
+    preconditions = ~ . %>% filter(!is.na(summary_results_date))
+  ) %>%
+  pointblank::col_vals_equal(
+    vars(has_summary_results),
+    FALSE,
+    preconditions = ~ . %>% filter(is.na(summary_results_date))
+  ) %>%
+  pointblank::col_vals_null(
+    vars(summary_results_date),
+    preconditions = ~ . %>% filter(!has_summary_results)
+  ) %>%
+  pointblank::col_vals_not_null(
+    vars(summary_results_date),
+    preconditions = ~ . %>% filter(has_summary_results)
   )


### PR DESCRIPTION
👋 @delwen ! Working on the trackvalue, I found a bug for the DRKS trials which have a summary results date (which we manually added), but having `has_summary_results` = FALSE. I corrected it here and added an assertion, to avoid this mishap reoccurring. I can't figure out quite how the bug got in there.

This also impacted one trackvalue report card, DRKS00011584, which we should re-run (once we pull in this corrected data) and can send out (either now or with the next reminder).